### PR TITLE
Fix missing feature in demo mode

### DIFF
--- a/src/btc_perp_trader/cli.py
+++ b/src/btc_perp_trader/cli.py
@@ -103,6 +103,7 @@ def run(mode: str, date_from: Optional[datetime], date_to: Optional[datetime]) -
         try:
             async for candle in feed.stream():
                 feats = candle.to_features()
+                feats.setdefault("headline", "")  # evita KeyError no modelo textual
                 long_p = ONLINE_MODEL.predict(feats)
                 short_p = 1 - long_p
                 price = candle.close


### PR DESCRIPTION
## Summary
- ensure `headline` feature exists in real-time inference

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas, numpy, trading_api, dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_68632c1a713c832c973e4787244db6f6