### PR TITLE
Fix headline default handling in demo mode

### DIFF
--- a/src/btc_perp_trader/cli.py
+++ b/src/btc_perp_trader/cli.py
@@ -103,7 +103,8 @@ def run(mode: str, date_from: Optional[datetime], date_to: Optional[datetime]) -
         try:
             async for candle in feed.stream():
                 feats = candle.to_features()
-                feats.setdefault("headline", "")  # evita KeyError no modelo textual
+                if "headline" not in feats:
+                    feats["headline"] = ""  # evita KeyError no modelo textual
                 long_p = ONLINE_MODEL.predict(feats)
                 short_p = 1 - long_p
                 price = candle.close


### PR DESCRIPTION
## Summary
- ensure `headline` field always exists before calling the online model

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68632db6ff04832cb3c833bf931a8956