### PR TITLE
Add offline training pipeline and dashboard

### DIFF
--- a/src/btc_perp_trader/backtest/generate_report.py
+++ b/src/btc_perp_trader/backtest/generate_report.py
@@ -1,43 +1,46 @@
+"""Gera um relatório HTML com estatísticas + lista de trades.
+
+Uso:
+    poetry run python -m btc_perp_trader.backtest.generate_report
+"""
+
 from pathlib import Path
+
+import pandas as pd  # noqa: WPS433
+
 from btc_perp_trader.backtest.vectorbt_backtest import run_backtest
-import pandas as pd
 
 
-def main():
-    # Executa back-test
+def main() -> None:
     pf = run_backtest()
-
-
-
-    # pf.stats() → Series. Converta em DataFrame p/ HTML (Pandas ≥2)
     stats = pf.stats()
-    
-    # Métricas adicionais
-    total_trades = int(pf.trades.count())
-    winning_trades = int(pf.trades.winning.count())
-    losing_trades = int(pf.trades.losing.count())
-    accuracy = stats.get("Win Rate [%]", 0)
-    
-    # Rendimento em % do valor investido
+
+    # métricas extras ---------------------------------------------------------
+    stats["Total Trades"] = int(pf.trades.count())
+    stats["Winning Trades"] = int(pf.trades.winning.count())
+    stats["Losing Trades"] = int(pf.trades.losing.count())
+    stats["Accuracy (%)"] = stats.get("Win Rate [%]", 0.0)
+
     initial_cash = pf.init_cash
-    final_value = pf.final_value()
-    if isinstance(final_value, pd.Series):
-        final_value = final_value.iloc[-1]
-    return_percentage = ((final_value - initial_cash) / initial_cash) * 100 if initial_cash > 0 else 0
+    final_value = pf.portfolio_value().iloc[-1]
+    stats["Return (%)"] = (
+        (final_value - initial_cash) / initial_cash * 100 if initial_cash else 0
+    )
 
-    # Adicionar ao DataFrame de estatísticas
-    stats["Total Trades"] = total_trades
-    stats["Winning Trades"] = winning_trades
-    stats["Losing Trades"] = losing_trades
-    stats["Accuracy (%)"] = accuracy
-    stats["Return (%)"] = return_percentage
-
-    html = stats.to_frame(name="value").to_html()
+    html = "\n".join(
+        [
+            "<h1>ROBOBTC2 – Relatório de Back-test</h1>",
+            "<h2>Resumo de métricas</h2>",
+            stats.to_frame(name="value").to_html(),
+            "<h2>Trades</h2>",
+            pf.trades.records_readable.to_html(index=False),
+        ]
+    )
 
     out = Path(__file__).parent / "report.html"
     out.write_text(html, encoding="utf-8")
-    print(f"✅ Relatório salvo em {out}")
+    print(f"✅ Relatório salvo em {out}")  # noqa: WPS421
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     main()

--- a/src/btc_perp_trader/dashboard/app.py
+++ b/src/btc_perp_trader/dashboard/app.py
@@ -1,0 +1,25 @@
+"""Dashboard Streamlit para monitorar dados e trades em tempo real.
+
+Execute:
+    poetry run streamlit run src/btc_perp_trader/dashboard/app.py
+"""
+
+import streamlit as st
+from btc_perp_trader.backtest.vectorbt_backtest import run_backtest
+from btc_perp_trader.models.train_ensemble import load_dataset
+
+st.set_page_config(layout="wide")
+st.title("\ud83d\udcc8 ROBOBTC2 – Monitor de Performance")
+
+# Dataset --------------------------------------------------------------------
+df = load_dataset()
+st.markdown("### Amostra de dados mais recentes")
+st.dataframe(df.tail(10))
+
+# Back-test -------------------------------------------------------------------
+st.markdown("### Estatísticas do back-test (vectorbt)")
+pf = run_backtest()
+st.dataframe(pf.stats().to_frame("value"))
+
+st.markdown("### Últimos trades")
+st.dataframe(pf.trades.records_readable.tail(50))

--- a/src/btc_perp_trader/pipeline/offline_train.py
+++ b/src/btc_perp_trader/pipeline/offline_train.py
@@ -1,7 +1,19 @@
-import datetime
+"""pipeline/offline_train.py
+
+Atualizado: 2025-07-02.
+
+* Permite definir data inicial via --start (default = 2023-01-01)
+* Gera dataset e mantém ponteiro data/latest_feats.pkl
+* Treina ensemble offline e pré-treina modelo on-line (River)
+"""
+
+import argparse
+import datetime as dt
 import pathlib
 import subprocess
-import sys
+import shutil
+import pickle
+import tqdm
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 DATA = ROOT / "data"
@@ -10,61 +22,77 @@ MODELS = ROOT / "models"
 MODELS.mkdir(exist_ok=True)
 
 
-def sh(cmd: str):
-    print("\u25b6", cmd)
-    sys.stdout.flush()
+def sh(cmd: str) -> None:
+    """Executa um comando shell exibindo-o antes."""
+    print("\u25b6", cmd, flush=True)
     subprocess.run(cmd, shell=True, check=True)
 
 
-def main():
-    today = datetime.date.today().isoformat()
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument(
+        "--start",
+        default="2023-01-01",
+        help="Data inicial YYYY-MM-DD para baixar candles/headlines",
+    )
+    return p.parse_args()
 
-    # 1. Baixar candles reais da Binance
-    ohlcv_csv = DATA / f"btc_1m_until_{today}.csv"
+
+def main():
+    args = parse_args()
+    today = dt.date.today().isoformat()
+
+    # 1) Candles ----------------------------------------------------------------
+    ohlcv_csv = DATA / f"btc_1m_{args.start}_{today}.csv"
     if not ohlcv_csv.exists():
         sh(
             f"python -m btc_perp_trader.data.fetch_binance "
-            f"--symbol BTCUSDT --interval 1m --start 2024-06-30 "
-            f"--out {ohlcv_csv}"
+            f"--symbol BTCUSDT --interval 1m --start {args.start} --out {ohlcv_csv}"
         )
 
-    # 2. Baixar ou atualizar as manchetes
+    # 2) Manchetes --------------------------------------------------------------
     headlines_json = DATA / "headlines.json"
     sh(
         f"python -m btc_perp_trader.data.fetch_news_history "
-        f"--start 2024-06-30 --out {headlines_json} --mode real"
+        f"--start {args.start} --out {headlines_json} --mode real"
     )
 
-    # 3. Gerar features
-    feats_pkl = DATA / f"btc_feats_{today}.pkl"
+    # 3) Features ---------------------------------------------------------------
+    feats_pkl = DATA / f"btc_feats_until_{today}.pkl"
     sh(
         f"python -m btc_perp_trader.models.build_dataset "
         f"--input {ohlcv_csv} --out {feats_pkl} --headlines-json {headlines_json}"
     )
 
-    # 4. Treinar modelo ensemble
+    # ponteiro 'latest' (link simbólico quando possível) -----------------------
+    latest = DATA / "latest_feats.pkl"
+    try:
+        if latest.exists() or latest.is_symlink():
+            latest.unlink()
+        latest.symlink_to(feats_pkl)
+    except (OSError, NotImplementedError):
+        shutil.copyfile(feats_pkl, latest)
+
+    # 4) Ensemble offline -------------------------------------------------------
     sh(
         f"python -m btc_perp_trader.models.train_ensemble "
         f"--dataset {feats_pkl} --out {MODELS / 'default.pkl'}"
     )
 
-    # 5. Treinar modelo online River
-    import pickle
+    # 5) Pré-treino on-line (River) --------------------------------------------
+    from btc_perp_trader.models.online_model import ONLINE_MODEL  # noqa: WPS433
+    import pandas as pd  # noqa: WPS433
 
-    import tqdm
+    df: pd.DataFrame = pickle.load(open(feats_pkl, "rb"))
+    labels = (df["close"].shift(-1) > df["close"]).astype(int)
 
-    from btc_perp_trader.models.online_model import ONLINE_MODEL
-
-    df = pickle.load(open(feats_pkl, "rb"))
     for x, y in tqdm.tqdm(
-        zip(
-            df.drop(columns=["close"]).to_dict("records"),
-            (df["close"].shift(-1) > df["close"]).astype(int),
-        ),
+        zip(df.drop(columns=["close"]).to_dict("records"), labels),
         total=len(df),
         desc="Pre-train River",
     ):
         ONLINE_MODEL.learn(x, int(y))
+
     print("ROC pré-treino:", ONLINE_MODEL.roc())
 
 


### PR DESCRIPTION
## Summary
- make offline training pipeline build dataset and pre-train River model
- train ensemble using latest dataset and CLI improvements
- generate HTML report with summary metrics and trades
- add simple Streamlit dashboard for monitoring

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv', 'trading_api', 'pandas', 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6864ae0be388832cb6d857f5db01d31c