### PR TITLE
Atualizar train_ensemble: datetimes para Unix time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ src/backtest/report.html
 src/btc_perp_trader/backtest/report.html
 **/__pycache__/
 .env
+
+# coverage files
+.coverage
+coverage.xml

--- a/src/btc_perp_trader/models/train_ensemble.py
+++ b/src/btc_perp_trader/models/train_ensemble.py
@@ -1,10 +1,7 @@
-"""Treino / utilitários para o EnsembleModel.
+"""Treino / utilitários para o EnsembleModel (versão 2025-07-02).
 
-• Procura sempre o dataset mais recente (`data/latest_feats.pkl` ou
-  o .pkl mais novo) e oferece uma CLI:
-
-    poetry run python -m btc_perp_trader.models.train_ensemble
-    poetry run python -m btc_perp_trader.models.train_ensemble --dataset data/btc_feats_until_2025-07-01.pkl --out models/meu_modelo.pkl
+• Converte colunas datetime64 → Unix-time antes de treinar  
+• `--dataset` agora força o EnsembleModel a usar exatamente esse arquivo
 """
 
 from __future__ import annotations
@@ -24,6 +21,8 @@ DATA_DIR = ROOT / "data"
 
 _logger = logging.getLogger(__name__)
 
+_FORCED_PATH: Optional[pathlib.Path] = None  # definido pelo CLI
+
 
 # --------------------------------------------------------------------------- #
 # helpers
@@ -40,17 +39,25 @@ def _latest_feats_path() -> Optional[pathlib.Path]:
     return pkls[0] if pkls else None
 
 
+def _coerce_datetimes(df: pd.DataFrame) -> pd.DataFrame:
+    """Transforma colunas datetime64[ns] em segundos Unix (float)."""
+    dt_cols = df.select_dtypes(include="datetime").columns
+    if len(dt_cols):
+        df = df.copy()
+        for col in dt_cols:
+            df[col] = df[col].view("int64") / 1_000_000_000  # ns → s
+    return df
+
+
 def load_dataset(path: pathlib.Path | None = None) -> pd.DataFrame:
-    """Carrega o DataFrame de features para treinar/avaliar modelos."""
-    if path:
-        return pickle.load(path.open("rb"))
-    p = _latest_feats_path()
-    if not p:
+    global _FORCED_PATH  # pragma: no cover
+    path = path or _FORCED_PATH or _latest_feats_path()
+    if not path:
         raise FileNotFoundError(
             "Nenhum dataset encontrado em 'data/'. Execute offline_train.py primeiro."
         )
-    _logger.info("Carregando dataset %s", p.name)
-    return pickle.load(p.open("rb"))
+    df = pickle.load(path.open("rb"))
+    return _coerce_datetimes(df)
 
 
 # --------------------------------------------------------------------------- #
@@ -74,19 +81,16 @@ def _parse_args():
 
 
 def main() -> None:
+    global _FORCED_PATH  # noqa: WPS420
     args = _parse_args()
-    df = load_dataset(args.dataset)
+    _FORCED_PATH = args.dataset  # garante que EnsembleModel use este dataset
 
-    _logger.info("Treinando EnsembleModel com %d amostras", len(df))
-    # Usa API interna do EnsembleModel — se existir _train_full_from_df, preferimos
-    mdl = (
-        EnsembleModel._train_full_from_df(df)  # type: ignore[attr-defined]
-        if hasattr(EnsembleModel, "_train_full_from_df")
-        else EnsembleModel._train_full(name="default")
-    )
+    # EnsembleModel internamente chamará train_ensemble.load_dataset()
+    _logger.info("Treinando EnsembleModel …")
+    model = EnsembleModel._train_full(name="default")
 
     with args.out.open("wb") as fh:
-        pickle.dump(mdl, fh)
+        pickle.dump(model, fh)
     print(f"✅ Modelo salvo em {args.out}")  # noqa: WPS421
 
 


### PR DESCRIPTION
## Summary
- convert datetime columns to Unix time before training
- make CLI `--dataset` strictly used by `EnsembleModel`
- ignore coverage outputs

## Testing
- `pip install -q pytest pytest-cov pytest-asyncio numpy pandas python-dotenv flask`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864b3d50b4c832c8fb9de838f8677fa